### PR TITLE
reintegrate 'get_celltype_correlation()'

### DIFF
--- a/ssam/__init__.py
+++ b/ssam/__init__.py
@@ -617,6 +617,11 @@ class SSAMDataset(object):
         """
         sns.heatmap(self.spatial_relationships, *args, xticklabels=cluster_labels, yticklabels=cluster_labels, **kwargs)    
 
+    def get_celltype_correlation(self, idx):
+        rtn = np.zeros_like(self.max_correlations) - 1
+        rtn[self.celltype_maps == idx] = self.max_correlations[self.celltype_maps == idx]
+        return rtn
+    
         
 class SSAMAnalysis(object):
     """


### PR DESCRIPTION
line 1271 calls self.dataset.get_celltype_correlation, but the function is gone : (
Just a quick fix, not sure if it comes with any follow-up errors, so better check this first