### PR TITLE
"norm" is not defined at this point any more.

### DIFF
--- a/ssam/__init__.py
+++ b/ssam/__init__.py
@@ -985,7 +985,7 @@ class SSAMAnalysis(object):
         else:
             vec = np.array(self.dataset.vf[self.dataset.local_maxs], copy=True)
         if normalize_gene:
-            vec = preprocessing.normalize(vec, norm=norm, axis=0) * size_after_normalization  # Normalize per gene
+            vec = preprocessing.normalize(vec, norm="l1", axis=0) * size_after_normalization  # Normalize per gene
         if normalize_vector:
             vec = preprocessing.normalize(vec, norm="l1", axis=1) * size_after_normalization # Normalize per vector
         if normalize_median:


### PR DESCRIPTION
could also include "norm='l1' " as a default function argument and pass it to 'preprocessing'. Not sure if works.